### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -107,7 +107,7 @@ after_initialize do
   module ::Jobs
 
     # This clears up users who have now moved offline
-    class WhosOnlineGoingOffline < Jobs::Scheduled
+    class WhosOnlineGoingOffline < ::Jobs::Scheduled
       every 1.minutes
 
       def execute(args)


### PR DESCRIPTION
Fix similar to that one: https://github.com/discourse/discourse-assign/commit/d59e7fe1fbe95789324010b3729d0589a8a9789f

This is necessary since Discourse moved to Zeitwerk autoloader