### PR TITLE
Fix deprecated warnings

### DIFF
--- a/assets/javascripts/discourse/services/online-service.js.es6
+++ b/assets/javascripts/discourse/services/online-service.js.es6
@@ -1,6 +1,7 @@
 import Ember from "ember";
 import { ajax } from "discourse/lib/ajax";
 import User from "discourse/models/user";
+import Site from "discourse/models/site";
 
 export default Ember.Service.extend({
   after: "message-bus",
@@ -106,7 +107,7 @@ export default Ember.Service.extend({
   },
 
   init() {
-    var startingData = Discourse.Site.currentProp("users_online");
+    var startingData = Site.currentProp("users_online");
 
     if (startingData) {
       this.set(

--- a/assets/javascripts/discourse/services/online-service.js.es6
+++ b/assets/javascripts/discourse/services/online-service.js.es6
@@ -9,7 +9,7 @@ export default Ember.Service.extend({
 
   users: [],
 
-  appEvents: Discourse.__container__.lookup("app-events:main"),
+  appEvents: Discourse.__container__.lookup("service:app-events"),
   siteSettings: Discourse.__container__.lookup("site-settings:main"),
 
   _lastMessageId: null,


### PR DESCRIPTION
Original warnings:

`Deprecation notice: "app-events:main" has been replaced with "service:app-events" (deprecated since Discourse 2.4.0)`

`Deprecation notice: Import the Site class instead of using Discourse.Site (deprecated since Discourse 2.4.0) (removal in Discourse 2.6.0)`