### PR TITLE
DEV: Fix a yaml lint issue

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,6 +1,6 @@
 en:
   js:
     whos_online:
-      title: "Online ({{count}}):"
+      title: "Online (%{count}):"
       tooltip: "Users seen in the last 5 minutes"
       no_users: "No users currently online"


### PR DESCRIPTION
```
The following keys use {{key}} instead of %{key} for interpolation keys:
  * js.whos_online.title
```