### PR TITLE
Update whos_online.scss

### DIFF
--- a/assets/stylesheets/whos_online.scss
+++ b/assets/stylesheets/whos_online.scss
@@ -124,6 +124,7 @@ html.whos-online-flair {
     left: 1px;
     height: 10px;
     width: 10px;
+    z-index: 1;
   }
 
   &.mobile-view .topic-avatar.user-online::before {


### PR DESCRIPTION
In the topic list, fixes the online flair being behind the avatars instead of in front of.

Before and after:

![image](https://user-images.githubusercontent.com/5654300/152538383-732024fd-07e4-4a5b-84f2-4a0e50fc97ba.png)

![image](https://user-images.githubusercontent.com/5654300/152538402-5b11b609-641e-4273-9fb1-6c275179dd51.png)
