### PR TITLE
DEV: Change settings root from plugins: to discourse_whos_online

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_whos_online: "Discourse Who's Online"
   js:
     whos_online:
       title:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_whos_online:
   whos_online_enabled:
     default: false
   whos_online_active_timeago:


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.