### PR TITLE
FIX: Use split hide profile and presence options

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta3-dev: 699113133bcdff762c42823aace5164161ac50d7
 < 3.4.0.beta1-dev: be99b48d01d65ffdb1f646996e9917b96da78bdc
 < 3.3.0.beta1-dev: 98b5a78d48a18fedb6075bb9c4eeaf7e3ebf96cc
 3.1.0.beta3: aeee51e439fae887b08b0eba29e8201b0bb1b88c

--- a/plugin.rb
+++ b/plugin.rb
@@ -31,9 +31,7 @@ after_initialize do
 
   on(:user_seen) do |user|
     hidden = false
-    hidden ||= user.user_option.hide_profile_and_presence if defined?(
-      user.user_option.hide_profile_and_presence
-    )
+    hidden ||= user.user_option.hide_presence if defined?(user.user_option.hide_presence)
     hidden ||= user.id < 0
     next if hidden
     PresenceChannel.new(DiscourseWhosOnline::CHANNEL_NAME).present(

--- a/spec/integration/whos_online_spec.rb
+++ b/spec/integration/whos_online_spec.rb
@@ -65,7 +65,7 @@ describe "whos online plugin", type: :request do
     expect(c.user_ids).to contain_exactly(user.id)
 
     user2 = Fabricate(:user)
-    user2.user_option.update(hide_profile_and_presence: true)
+    user2.user_option.update(hide_presence: true)
     sign_in(user2)
     get "/latest.json"
     expect(c.user_ids).to contain_exactly(user.id)


### PR DESCRIPTION
It uses the `hide_presence` user option introduced in https://github.com/discourse/discourse/pull/29632