### PR TITLE
FIX: cannot read property of undefined

### DIFF
--- a/assets/javascripts/discourse/api-initializers/intitialize-whos-online-indicators.js
+++ b/assets/javascripts/discourse/api-initializers/intitialize-whos-online-indicators.js
@@ -78,12 +78,13 @@ export default apiInitializer("1.39.0", (api) => {
       value: additionalClasses,
       context: { topic },
     }) => {
-      const whosOnline = api.container.lookup("service:whos-online");
-      const lastPosterId = topic.lastPoster.id;
-      const lastPosterUserId = topic.lastPosterUser.id;
+      if (topic) {
+        const whosOnline = api.container.lookup("service:whos-online");
+        const { lastPoster, lastPosterUser } = topic;
 
-      if (whosOnline.isUserOnline(lastPosterId || lastPosterUserId)) {
-        additionalClasses.push("last-poster-online");
+        if (whosOnline.isUserOnline(lastPoster?.id || lastPosterUser?.id)) {
+          additionalClasses.push("last-poster-online");
+        }
       }
 
       return additionalClasses;


### PR DESCRIPTION
When upgrading this component to use the Glimmer topic list, we converted @discourseComputed into value transformers but there's a bit of magic with @discourseComputed when it comes to handling `.` and `null` / `undefined` values.

This ensures the same behaviour and prevents the JS error from happening when creating a new topic from the topic list.

Meta - https://meta.discourse.org/t/349416