### PR TITLE
DEV: Replace `findBy` with native `.find` in JavaScript code

### DIFF
--- a/assets/javascripts/discourse/services/whos-online.js
+++ b/assets/javascripts/discourse/services/whos-online.js
@@ -52,6 +52,6 @@ export default class WhosOnlineService extends Service {
   }
 
   isUserOnline(id) {
-    return !!this.channel?.users?.findBy("id", id);
+    return !!this.channel?.users?.find((user) => user.id === id);
   }
 }


### PR DESCRIPTION
Refactor deprecated `findBy` usage to use native array methods like `.find`. 

This resolves warnings in `discourse.native-array-extensions` and ensures future compatibility with updated Ember versions.